### PR TITLE
resolving unicode to str error

### DIFF
--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -18,7 +18,11 @@ import getpass
 from binascii import hexlify
 import sys
 
-from io import StringIO, BytesIO
+if sys.version < '3':
+    from StringIO import StringIO
+else: 
+    from io import StringIO
+from io import BytesIO
 from lxml import etree
 from select import select
 

--- a/ncclient/xml_.py
+++ b/ncclient/xml_.py
@@ -19,7 +19,11 @@
 import io
 import sys
 
-from io import StringIO, BytesIO
+if sys.version < '3':
+    from StringIO import StringIO
+else:
+    from io import StringIO
+from io import BytesIO
 from lxml import etree
 
 # In case issues come up with XML generation/parsing


### PR DESCRIPTION
Resolving error:
jnpr.junos.exception.ConnectError: ConnectError(host: 10.209.16.204, msg: unicode argument expected, got 'str’)
